### PR TITLE
fix backslash escape interpretation

### DIFF
--- a/toolbox-css.sh
+++ b/toolbox-css.sh
@@ -5,7 +5,7 @@ function randomLine {
     local selectedLine=''
     local i=1
     
-    while read line; do
+    while read -r line; do
     
         # If line is empty, ignore.
         if [ -z "$line" ]; then


### PR DESCRIPTION
add -r option to read to prevent read from interpreting backslash escapes

There should be a newline where there is a "n" here:
![image](https://user-images.githubusercontent.com/7536298/53182493-e369c780-35f9-11e9-8a2f-c07b42a5b6f2.png)
